### PR TITLE
module: add zephyr module dir and yaml

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,5 @@
+name: thrift
+build:
+  cmake-ext: True
+  kconfig-ext: True
+


### PR DESCRIPTION
Add a basic `zephyr/module.yaml` entry to enable integration with Zephyr's build system.

Zephyr module integration should be done in the main Zephyr tree.

This change itself should eventually go upstream and the preference for this project would be to have all changes go upstream first.

So in a sense, the fork of `apache/thrift` to
`zephyrproject-rtos/thrift` should be kept as redundant as possible so that it could be replaced with the upstream project at any time.
